### PR TITLE
Update isa_archive_creator.py to use old parser

### DIFF
--- a/lambda_function/lambda_utils/isa_archive_creator.py
+++ b/lambda_function/lambda_utils/isa_archive_creator.py
@@ -106,7 +106,8 @@ class IsaArchiveCreator:
             # Reset isa_json file pointer after read in _validate_isa_json()
             isa_json.seek(0)
             json2isatab.convert(
-                isa_json, self.conversion_dir, validate_first=False
+                isa_json, self.conversion_dir, 
+                use_new_parser=False, validate_first=False
             )
 
     def _create_isa_archive(self, investigation_file_object):


### PR DESCRIPTION
- SCC Isa-Tabs will generally only validate against the old parser. It may be good to catch errors while using the new parser, and falling back to the old one only as necessary